### PR TITLE
Add Chrystoki.conf file to the data secret

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,2 +1,1 @@
 Ade Lee <alee@redhat.com>
-Douglas Mendizábal <dmendiza@redhat.com>

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ You can also do the steps separately.
 * `luna_data_secret`: (String) Name of the secret that stores all of the needed certs for luna.  Default value: `barbican-luna-data`
 * `luna_data_secret_namespace`: (String) Namespace of the secret that stores all of the needed certs for luna.  Default value: `openstack`
 * `login_secret`: (String) The secret to store the password to log into the HSM partition. Default: `hsm-login`
+* `login_secret_field`: (String) key to store partition_password in Login_secret.  Default: `PKCS11Pin`
 * `partition_password`: (String) Password to log into the HSM Partition
 * `kubeconfig_path`: (String) Path to kubeconfig file
 * `oc_path`: (String) Path to oc binary

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ role to complete successfully.
     this will be a concatenation of all the server certs for the servers in the HA partition.
   * The client certificate and key made available at luna_client_cert_src.  The files are expected
     to be of the form "(client_ip)".pem and "(client_ip)"Key.pem
-* The certs will be retrieved and stored in a secret (luna_cert_secret)
+  * The Chrystoki.conf is available at chrystoki_conf_src.
+* The certs and Chrystoki.conf will be retrieved and stored in a secret (luna_data_secret)
 * The password to log into the HSM partition will be stored in a secret (login_secret)
 
 A minimal (one that takes the defaults) invocation of this role is shown below.  In this case, the lunaclient
@@ -63,12 +64,13 @@ You can also do the steps separately.
 * `luna_binaries_src`: (String) Location of the luna binaries. Default value: `file:///opt/luna/bin`
 
 ### Secret Generation Variables
+* `chrystoki_conf_src`: (String) Location of Chrystoki.conf file. Default value: `file:///opt/luna/Chrystoki.conf`
 * `luna_server_cert_src`: (String) Location of HSM server CA cert.  Default value: `file:///opt/luna/cert/server/cacert.pem`
 * `luna_client_cert_src`: (String) Location of HSM client certs.  Default value: `file:///opt/luna/cert/client`
 * `server_ca_file`: (String) Name of the cacert file in the container.  Default value: `cacert.pem`
 * `client_ip`: (String) ip address or hostname of the client VM
-* `luna_cert_secret`: (String) Name of the secret that stores all of the needed certs for luna.  Default value: `barbican-luna-certs`
-* `luna_cert_secret_namespace`: (String) Namespace of the secret that stores all of the needed certs for luna.  Default value: `openstack`
+* `luna_data_secret`: (String) Name of the secret that stores all of the needed certs for luna.  Default value: `barbican-luna-data`
+* `luna_data_secret_namespace`: (String) Namespace of the secret that stores all of the needed certs for luna.  Default value: `openstack`
 * `login_secret`: (String) The secret to store the password to log into the HSM partition. Default: `hsm-login`
 * `partition_password`: (String) Password to log into the HSM Partition
 * `kubeconfig_path`: (String) Path to kubeconfig file

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -28,9 +28,10 @@ luna_minclient_src: "file:///opt/luna/Linux-Minimal-Client.tar.gz"
 luna_binaries_src: "file:///opt/luna/bin/"
 luna_server_cert_src: "file:///opt/luna/cert/server/cacert.pem"
 luna_client_cert_src: "file:///opt/luna/cert/client/"
+chrystoki_conf_src: "file:///opt/luna/Chrystoki.conf"
 server_ca_file: "cacert.pem"
-luna_cert_secret: "barbican-luna-certs"
-luna_cert_secret_namespace: "openstack"
+luna_data_secret: "barbican-luna-data"
+luna_data_secret_namespace: "openstack"
 
 ## Image details
 barbican_src_image_registry: "quay.io"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -32,6 +32,7 @@ chrystoki_conf_src: "file:///opt/luna/Chrystoki.conf"
 server_ca_file: "cacert.pem"
 luna_data_secret: "barbican-luna-data"
 luna_data_secret_namespace: "openstack"
+login_secret_field: "PKCS11Pin"
 
 ## Image details
 barbican_src_image_registry: "quay.io"

--- a/tasks/create_secrets.yml
+++ b/tasks/create_secrets.yml
@@ -23,7 +23,7 @@
   loop:
     - "{{ working_dir }}/certs"
 
-- name: Get certs and keys
+- name: Get certs, keys and Chrystoki.conf
   block:
     - name: Get the server CA cert
       ansible.builtin.get_url:
@@ -43,17 +43,23 @@
         dest: "{{ working_dir }}/certs/"
         mode: "0600"
 
+    - name: Get Chrystoki.conf
+      ansible.builtin.get_url:
+        url: "{{ chrystoki_conf_src }}"
+        dest: "{{ working_dir }}/Chrystoki.conf"
+        mode: "0600"
+
 - name: Write out the HSM cert secret template file
   ansible.builtin.template:
-    src: "luna_cert_secret.yml.j2"
-    dest: "{{ working_dir }}/luna_cert_secret.yml"
+    src: "luna_data_secret.yml.j2"
+    dest: "{{ working_dir }}/luna_data_secret.yml"
     mode: "0600"
 
 - name: Create the HSM cert secret
   environment:
     KUBECONFIG: "{{ kubeconfig_path }}"
     PATH: "{{ oc_path }}"
-  ansible.builtin.command: "oc apply -f {{ working_dir }}/luna_cert_secret.yml"
+  ansible.builtin.command: "oc apply -f {{ working_dir }}/luna_data_secret.yml"
 
 - name: Write out the hsm-login secret
   ansible.builtin.template:

--- a/templates/login_secret.yml.j2
+++ b/templates/login_secret.yml.j2
@@ -3,6 +3,6 @@ kind: Secret
 type: Opaque
 metadata:
   name: "{{ login_secret }}"
-  namespace: "{{ luna_cert_secret_namespace }}"
+  namespace: "{{ luna_data_secret_namespace }}"
 data:
   "hsmLogin": "{{ partition_password | string | b64encode }}"

--- a/templates/login_secret.yml.j2
+++ b/templates/login_secret.yml.j2
@@ -5,4 +5,4 @@ metadata:
   name: "{{ login_secret }}"
   namespace: "{{ luna_data_secret_namespace }}"
 data:
-  "hsmLogin": "{{ partition_password | string | b64encode }}"
+  "{{ login_secret_field }}": "{{ partition_password | string | b64encode }}"

--- a/templates/luna_data_secret.yml.j2
+++ b/templates/luna_data_secret.yml.j2
@@ -2,9 +2,10 @@ apiVersion: v1
 kind: Secret
 type: Opaque
 metadata:
-  name: "{{ luna_cert_secret }}"
-  namespace: "{{ luna_cert_secret_namespace }}"
+  name: "{{ luna_data_secret }}"
+  namespace: "{{ luna_data_secret_namespace }}"
 data:
+  "Chrystoki.conf": "{{ lookup('ansible.builtin.file', working_dir + '/Chrystoki.conf') |string |b64encode }}"
   "{{ client_ip }}.pem": "{{ lookup('ansible.builtin.file', working_dir + '/certs/' + client_ip + '.pem') | string | b64encode }}"
   "{{ client_ip }}Key.pem": "{{ lookup('ansible.builtin.file', working_dir + '/certs/' + client_ip + 'Key.pem') | string | b64encode }}"
   "CACert.pem": "{{ lookup('ansible.builtin.file', working_dir + '/certs/' + server_ca_file) | string | b64encode }}"


### PR DESCRIPTION
We have decided to include the Chrystoki.conf file as part of the secret that is passed into the barbican-operator to set up the barbican instance.  The new secret will now include the Chrystoki.conf file as well as the needed certs.

The role has been modified to download the Chrystoki.conf file from a specified location and add it to the secret. 