### PR TITLE
Refactor create_image and create_secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ You can also do the steps separately.
         luna_minclient_src: "file:///opt/luna/LunaClient-Minimal-{{ luna_minclient_version }}.x86_64.tar"
        tasks:
        - name: Create new barbican images with the Luna Minimal Client
-         ansible.builtin.includ_role:
+         ansible.builtin.include_role:
            name: rhoso_luna_hsm
            tasks_from: create_image
 

--- a/README.md
+++ b/README.md
@@ -1,35 +1,37 @@
 # rhoso-luna-hsm Role
 
-In order to use HSMs, the barbican images need to be customized to include the HSM software.
+In order to use Thales Luna Network HSMs as a PKCS#11 backend, the Barbican
+images need to be customized to include the [Luna HSM Client](https://www.thalesdocs.com/gphsm/luna/7/docs/network/Content/Home_Luna.htm) software.
 
 The purpose of this role is to:
-* Generate new images for the barbican-api and barbican-worker containing the HSM software
-* Upload those images to a private repository for use in setting up a CI job.
-* Create any required config to be mounted by the barbican images to interact with the HSM
+* Generate new images for the barbican-api and barbican-worker containing the
+  [Luna Minimal Client](https://www.thalesdocs.com/gphsm/luna/7/docs/network/Content/install/client_install/linux_docker_minimal_extended.htm)
+* Upload those images to a private repository for use in a RHOSO deployment.
+* Create any required config to be mounted by the barbican images for connecting to the HSMs
+  using [NTLS](https://www.thalesdocs.com/gphsm/luna/7/docs/network/Content/admin_partition/connections/connections.htm#NTLS)
 
-For the Lunasa, we expect some preparatory steps to be completed prior to execution in order for the
-role to complete successfully.
-* The lunasa software is uploaded somewhere and will be fetched by the role
-  * The contents of the minimal linux client in a zipped tar file should be made available at luna_minclient_src.
-  * The lunasa binaries that need to be added to the image are made available at luna_binaries_src.
-  * The lunasa HSM cacert file is made available at luna_server_cert_src.  For an HA configuration,
-    this will be a concatenation of all the server certs for the servers in the HA partition.
+We expect some preparatory steps to be completed prior to execution in order for the
+role to complete successfully:
+* The Luna Minimal Client tarball has been downloaded from Thales
+  * The location of the Luna Minimal Client tarball should be made available at luna_minclient_src.
+  * The HSM Appliance Server Certificate (server.pem) file is made available at luna_server_cert_src.
+    When using more than one HSM appliance, this file will be a concatenation of all the server certificates.
   * The client certificate and key made available at luna_client_cert_src.  The files are expected
-    to be of the form "(client_ip)".pem and "(client_ip)"Key.pem
+    to be of the form $(CLIENT_NAME).pem and $(CLIENT_NAME)Key.pem
   * The Chrystoki.conf is available at chrystoki_conf_src.
-* The certs and Chrystoki.conf will be retrieved and stored in a secret (luna_data_secret)
-* The password to log into the HSM partition will be stored in a secret (login_secret)
+* The certs and Chrystoki.conf will be retrieved from the given locations and stored in a secret (luna_data_secret)
+* The PIN (password) to log into the HSM partition will be stored in a secret (login_secret)
 
-A minimal (one that takes the defaults) invocation of this role is shown below.  In this case, the lunaclient
-software and certs are stored locally under /opt/luna.
+A minimal (one that takes the defaults) invocation of this role is shown below.  In this case, the Luna Minimal Client
+software and required certificates and configuration files are stored locally under /opt/luna.
 
-- name: Set up Luna
-  ansible.builtin.include_role: rhoso_luna_hsm
-  vars:
-    client_ip: "IP of the client - this could be the hypervisor where the Openshift nodes run"
-    partition_password: "password to log into partition"
-    kubeconfig_path: "path to kubeconfig file"
-    oc_path: "path to oc binary"
+    - name: Set up Luna
+      ansible.builtin.include_role: rhoso_luna_hsm
+      vars:
+        client_ip: "IP of the client - this could be the hypervisor where the Openshift nodes run"
+        partition_password: "password to log into partition"
+        kubeconfig_path: "path to kubeconfig file"
+        oc_path: "path to oc binary"
 
 You can also do the steps separately.
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ role to complete successfully:
   * The HSM Appliance Server Certificate (server.pem) file is made available at luna_server_cert_src.
     When using more than one HSM appliance, this file will be a concatenation of all the server certificates.
   * The client certificate and key made available at luna_client_cert_src.  The files are expected
-    to be of the form $(CLIENT_NAME).pem and $(CLIENT_NAME)Key.pem
+    to be of the form "{{ client_name }}.pem" and "{{ client_name }}Key.pem"
   * The Chrystoki.conf is available at chrystoki_conf_src.
 * The certs and Chrystoki.conf will be retrieved from the given locations and stored in a secret (luna_data_secret)
 * The PIN (password) to log into the HSM partition will be stored in a secret (login_secret)
@@ -25,56 +25,78 @@ role to complete successfully:
 A minimal (one that takes the defaults) invocation of this role is shown below.  In this case, the Luna Minimal Client
 software and required certificates and configuration files are stored locally under /opt/luna.
 
-    - name: Set up Luna
-      ansible.builtin.include_role: rhoso_luna_hsm
+    ---
+    - hosts: localhost
       vars:
-        client_ip: "IP of the client - this could be the hypervisor where the Openshift nodes run"
-        partition_password: "password to log into partition"
-        kubeconfig_path: "path to kubeconfig file"
-        oc_path: "path to oc binary"
+        barbican_dest_image_namespace: "{{ your quay.io account name }}"
+        luna_minclient_version: "10.7.2-16"
+        luna_minclient_src: "file:///opt/luna/LunaClient-Minimal-{{ luna_minclient_version }}.x86_64.tar"
+        luna_client_name: "{{ name used for client certificate }}"
+        luna_partition_password: "{{ password to log into luna partition }}"
+        kubeconfig_path: "/path/to/.kube/config"
+        oc_dir: "/path/to/oc/bin/dir/"
+      roles:
+        - rhoso_luna_hsm
 
 You can also do the steps separately.
 
-- name: Create new barbican image with the hsm software
-  ansible.builtin.include_role: rhoso_luna_hsm
-  tasks_from: create_image.yml
+    ---
+    - hosts: localhost
+      vars:
+        barbican_dest_image_namespace: "{{ your quay.io account name }}"
+        luna_minclient_version: "10.7.2-16"
+        luna_minclient_src: "file:///opt/luna/LunaClient-Minimal-{{ luna_minclient_version }}.x86_64.tar"
+       tasks:
+       - name: Create new barbican images with the Luna Minimal Client
+         ansible.builtin.includ_role:
+           name: rhoso_luna_hsm
+           tasks_from: create_image
 
-- name: Create secrets containing the certs and partition password
-  ansible.builtin.include_role: rhoso_luna_hsm
-  tasks_from: create_secrets.yml
-  vars:
-    client_ip: "IP of the client - this could be the hypervisor where the Openshift nodes run"
-    partition_password: "password to log into partition"
-    kubeconfig_path: "path to kubeconfig file"
-    oc_path: "path to oc binary"
-
+    ---
+    - hosts: localhost
+      vars:
+        luna_client_name: "{{ name used for client certificate }}"
+        luna_partition_password: "{{ password to log into luna partition }}"
+        kubeconfig_path: "/path/to/.kube/config"
+        oc_dir: "/path/to/oc/bin/dir/"
+      tasks:
+      - name: Create secrets containing NTLS certificates and partition password
+        ansible.builtin.include_role:
+          name: rhoso_luna_hsm
+          tasks_from: create_certs
 
 ## Role Variables
 
 ### Role Parameters
-* `cleanup`: (Boolean) Delete all resources created by the role at the end of the testing. Default value: `false`
-* `working_dir`: (String) Working directory to store artifacts.  Default value: `/tmp/hsm-prep-working-dir`
+| Variable      | Type    | Default Value               | Description                                                     |
+| ------------- | ------- | --------------------------- | --------------------------------------------------------------- |
+| `cleanup`     | boolean | `false`                     | Delete all resources created by the role at the end of the run. |
+| `working_dir` | string  | `/tmp/hsm-prep-working-dir` | Working directory to store artifacts.                           |
 
 ### Image Generation Variables
-* `barbican_src_image_registry`: (String) Registry of the source image. Default value: `quay.io`
-* `barbican_src_image_namespace: (String) Namespace of the source image. Default value: `podified-antelope-centos9`
-* `barbican_src_image_tag: (String) Tag of the source image. Default value: `current-podified`
-* `barbican_dest_image_registry`: (String) Registry of the modified image. Default value: `quay.io`
-* `barbican_dest_image_namespace: (String) Namespace of the modified image. Default value: `podified-antelope-centos9`
-* `barbican_dest_image_tag: (String) Tag of the modified image. Default value: `current-podified-luna`
-* `luna_minclient_src`: (String) Location of linux minimal client tarball. Default value: `file:///opt/luna/Linux-Minimal-Client.tar.gz`
-* `luna_binaries_src`: (String) Location of the luna binaries. Default value: `file:///opt/luna/bin`
+| Variable                        | Type   | Default Value                                              | Description                                                                        |
+| ------------------------------- | ------ | ---------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| `barbican_src_image_registry`   | string | `quay.io`                                                  | Registry used to pull down the Barbican images                                     |
+| `barbican_src_image_namespace`  | string | `podified-antelope-centos9`                                | Registry namespace for the Barbican images                                         |
+| `barbican_src_image_tag`        | string | `current-podified`                                         | Tag used to identify the source images                                             |
+| `barbican_dest_image_registry`  | string | `quay.io`                                                  | Registry used to push the modified images                                          |
+| `barbican_dest_image_namespace` | string | `podified-antelope-centos9`                                | Registry namespace for the modified images                                         |
+| `barbican_dest_image_tag`       | string | `current-podified-luna`                                    | Tag used to identify the modified images                                           |
+| `luna_minclient_src`            | string | `file:///opt/luna/LunaClient-Minimal-10.7.2-16.x86_64.tar` | Location of the Luna Minimal Client tarball                                        |
+| `luna_minclient_version`        | string | `10.7.2-16`                                                | Version string used to locate the directory inside the Luna Minimal Client Tarball |
 
 ### Secret Generation Variables
-* `chrystoki_conf_src`: (String) Location of Chrystoki.conf file. Default value: `file:///opt/luna/Chrystoki.conf`
-* `luna_server_cert_src`: (String) Location of HSM server CA cert.  Default value: `file:///opt/luna/cert/server/cacert.pem`
-* `luna_client_cert_src`: (String) Location of HSM client certs.  Default value: `file:///opt/luna/cert/client`
-* `server_ca_file`: (String) Name of the cacert file in the container.  Default value: `cacert.pem`
-* `client_ip`: (String) ip address or hostname of the client VM
-* `luna_data_secret`: (String) Name of the secret that stores all of the needed certs for luna.  Default value: `barbican-luna-data`
-* `luna_data_secret_namespace`: (String) Namespace of the secret that stores all of the needed certs for luna.  Default value: `openstack`
-* `login_secret`: (String) The secret to store the password to log into the HSM partition. Default: `hsm-login`
-* `login_secret_field`: (String) key to store partition_password in Login_secret.  Default: `PKCS11Pin`
-* `partition_password`: (String) Password to log into the HSM Partition
-* `kubeconfig_path`: (String) Path to kubeconfig file
-* `oc_path`: (String) Path to oc binary
+| Variable                     | Type   | Default Value                             | Description                                                                                   |
+| ---------------------------- | ------ | ----------------------------------------- | --------------------------------------------------------------------------------------------- |
+| `kubeconfig_path`            | string | None                                      | Full path to kubeconfig file. e.g. `/home/user/.kube/config`                                  |
+| `oc_dir`                     | string | None                                      | Full path to the directory containing the `oc` command binary. e.g. `/home/user/.crc/bin/oc/` |
+| `luna_client_name`           | string | None                                      | Name of the client certificate.  This must match the certificate and key file names           |
+| `luna_partition_password`    | string | None                                      | Password (SO PIN) used to log into the HSM partition                                          |
+| `chrystoki_conf_src`         | string | `file:///opt/luna/Chrystoki.conf`         | Full path to the Chrystoki.conf file                                                          |
+| `luna_server_cert_src`       | string | `file:///opt/luna/cert/server/server.pem` | Full path to the HSM server certificate                                                       |
+| `luna_client_cert_src`       | string | `file:///opt/luna/cert/client`            | Directory path to the directory containing the client certificate and key                     |
+| `server_ca_file`             | string | `CAFile.pem`                              | Name to be used for the server certificate once mounted on the container                      |
+| `luna_data_secret`           | string | `barbican-luna-data`                      | Name of the secret used to store client and server certificates                               |
+| `luna_data_secret_namespace` | string | `openstack`                               | Namespace to be used when creating `luna_data_secret`                                         |
+| `login_secret`               | string | `hsm-login`                               | Name of the secret used to store the password to log into the HSM partition                   |
+| `login_secret_field`         | string | `PKCS11Pin`                               | Secret key used to store the `luna_partition_password` data in `login_secret`                 |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -24,12 +24,12 @@ cleanup: false
 working_dir: "/tmp/hsm-prep-working-dir"
 
 ### Luna Parameters
-luna_minclient_src: "file:///opt/luna/Linux-Minimal-Client.tar.gz"
-luna_binaries_src: "file:///opt/luna/bin/"
-luna_server_cert_src: "file:///opt/luna/cert/server/cacert.pem"
+luna_minclient_src: "file:///opt/luna/LunaClient-Minimal-10.7.2-16.x86_64.tar"
+luna_minclient_version: "10.7.2-16"
+luna_server_cert_src: "file:///opt/luna/cert/server/server.pem"
 luna_client_cert_src: "file:///opt/luna/cert/client/"
 chrystoki_conf_src: "file:///opt/luna/Chrystoki.conf"
-server_ca_file: "cacert.pem"
+server_ca_file: "CAFile.pem"
 luna_data_secret: "barbican-luna-data"
 luna_data_secret_namespace: "openstack"
 login_secret_field: "PKCS11Pin"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,9 +16,6 @@
 
 # defaults file for the ansible-role-rhoso-luna-hsm role
 
-# HSM Details
-login_secret: "hsm-login"
-
 ### Role Parameters
 cleanup: false
 working_dir: "/tmp/hsm-prep-working-dir"
@@ -28,13 +25,15 @@ luna_minclient_src: "file:///opt/luna/LunaClient-Minimal-10.7.2-16.x86_64.tar"
 luna_minclient_version: "10.7.2-16"
 luna_server_cert_src: "file:///opt/luna/cert/server/server.pem"
 luna_client_cert_src: "file:///opt/luna/cert/client/"
+luna_client_name: "barbican"
 chrystoki_conf_src: "file:///opt/luna/Chrystoki.conf"
 server_ca_file: "CAFile.pem"
 luna_data_secret: "barbican-luna-data"
 luna_data_secret_namespace: "openstack"
+login_secret: "hsm-login"
 login_secret_field: "PKCS11Pin"
 
-## Image details
+### Image details
 barbican_src_image_registry: "quay.io"
 barbican_src_image_namespace: "podified-antelope-centos9"
 barbican_src_image_tag: "current-podified"

--- a/tasks/create_image.yml
+++ b/tasks/create_image.yml
@@ -39,17 +39,6 @@
         src: "{{ working_dir }}/{{ luna_minclient_src | basename }}"
         dest: "{{ working_dir }}/client/"
 
-    - name: Get the binaries
-      ansible.builtin.get_url:
-        url: "{{ luna_binaries_src }}/{{ item }}"
-        dest: "{{ working_dir }}/bin/"
-        mode: "0770"
-      loop:
-        - "vtl"
-        - "lunacm"
-        - "multitoken"
-        - "ckdemo"
-
 - name: Download build tools
   become: true
   ansible.builtin.dnf:
@@ -67,8 +56,7 @@
     BARBICAN_DEST_IMAGE_REGISTRY: "{{ barbican_dest_image_registry }}"
     BARBICAN_DEST_IMAGE_NAMESPACE: "{{ barbican_dest_image_namespace }}"
     BARBICAN_DEST_IMAGE_TAG: "{{ barbican_dest_image_tag }}"
-    LUNA_LINUX_MINIMAL_CLIENT_DIR: "{{ working_dir }}/client/linux-minimal"
-    LUNA_CLIENT_BIN: "{{ working_dir }}/bin"
+    LUNA_LINUX_MINIMAL_CLIENT_DIR: "{{ working_dir }}/client/LunaClient-Minimal-{{ luna_minclient_version }}.x86_64"
 
 - name: Perform cleanup tasks
   when:

--- a/tasks/create_secrets.yml
+++ b/tasks/create_secrets.yml
@@ -33,13 +33,13 @@
 
     - name: Get client cert
       ansible.builtin.get_url:
-        url: "{{ luna_client_cert_src }}/{{ client_ip }}.pem"
+        url: "{{ luna_client_cert_src }}/{{ luna_client_name }}.pem"
         dest: "{{ working_dir }}/certs/"
         mode: "0600"
 
     - name: Get client key
       ansible.builtin.get_url:
-        url: "{{ luna_client_cert_src }}/{{ client_ip }}Key.pem"
+        url: "{{ luna_client_cert_src }}/{{ luna_client_name }}Key.pem"
         dest: "{{ working_dir }}/certs/"
         mode: "0600"
 
@@ -58,7 +58,7 @@
 - name: Create the HSM cert secret
   environment:
     KUBECONFIG: "{{ kubeconfig_path }}"
-    PATH: "{{ oc_path }}"
+    PATH: "{{ oc_dir }}"
   ansible.builtin.command: "oc apply -f {{ working_dir }}/luna_data_secret.yml"
 
 - name: Write out the hsm-login secret
@@ -70,15 +70,20 @@
 - name: Create the hsm-login secret
   environment:
     KUBECONFIG: "{{ kubeconfig_path }}"
-    PATH: "{{ oc_path }}"
+    PATH: "{{ oc_dir }}"
   ansible.builtin.command: "oc apply -f {{ working_dir }}/login_secret.yml"
 
 - name: Perform cleanup tasks
   when:
     - cleanup | bool
   block:
-    - name: Remove the working directory
+    - name: Remove the working directory and generated yaml files
       become: true
       ansible.builtin.file:
-        path: "{{ working_dir }}/certs"
+        path: "{{ item }}"
         state: absent
+      loop:
+        - "{{ working_dir }}/certs"
+        - "{{ working_dir }}/Chrystoki.conf"
+        - "{{ working_dir }}/luna_data_secret.yml"
+        - "{{ working_dir }}/login_secret.yml"

--- a/templates/login_secret.yml.j2
+++ b/templates/login_secret.yml.j2
@@ -5,4 +5,4 @@ metadata:
   name: "{{ login_secret }}"
   namespace: "{{ luna_data_secret_namespace }}"
 data:
-  "{{ login_secret_field }}": "{{ partition_password | string | b64encode }}"
+  "{{ login_secret_field }}": "{{ luna_partition_password | string | b64encode }}"

--- a/templates/luna_data_secret.yml.j2
+++ b/templates/luna_data_secret.yml.j2
@@ -6,6 +6,6 @@ metadata:
   namespace: "{{ luna_data_secret_namespace }}"
 data:
   "Chrystoki.conf": "{{ lookup('ansible.builtin.file', working_dir + '/Chrystoki.conf') |string |b64encode }}"
-  "{{ client_ip }}.pem": "{{ lookup('ansible.builtin.file', working_dir + '/certs/' + client_ip + '.pem') | string | b64encode }}"
-  "{{ client_ip }}Key.pem": "{{ lookup('ansible.builtin.file', working_dir + '/certs/' + client_ip + 'Key.pem') | string | b64encode }}"
+  "{{ luna_client_name }}.pem": "{{ lookup('ansible.builtin.file', working_dir + '/certs/' + luna_client_name + '.pem') | string | b64encode }}"
+  "{{ luna_client_name }}Key.pem": "{{ lookup('ansible.builtin.file', working_dir + '/certs/' + luna_client_name + 'Key.pem') | string | b64encode }}"
   "CACert.pem": "{{ lookup('ansible.builtin.file', working_dir + '/certs/' + server_ca_file) | string | b64encode }}"


### PR DESCRIPTION
This patch changes the create_image tasks to use the Linux Minimal client as provided by Thales.

Adding binaries is not necessary because they are included in recent versions of the minimal client.