### PR TITLE
Remove luna_minclient_dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,7 @@ software and required certificates and configuration files are stored locally un
     - hosts: localhost
       vars:
         barbican_dest_image_namespace: "{{ your quay.io account name }}"
-        luna_minclient_dir: "LunaClient-Minimal-10.7.2-16.x86_64"
-        luna_minclient_src: "file:///opt/luna/{{ luna_minclient_dir }}.tar"
+        luna_minclient_src: "file:///opt/luna/LunaClient-Minimal-10.7.2-16.x86_64.tar"
         luna_client_name: "{{ name used for client certificate }}"
         luna_partition_password: "{{ password to log into luna partition }}"
         kubeconfig_path: "/path/to/.kube/config"
@@ -44,8 +43,7 @@ You can also do the steps separately.
     - hosts: localhost
       vars:
         barbican_dest_image_namespace: "{{ your quay.io account name }}"
-        luna_minclient_dir: "LunaClient-Minimal-10.7.2-16.x86_64"
-        luna_minclient_src: "file:///opt/luna/{{ luna_minclient_dir }}.tar"
+        luna_minclient_src: "file:///opt/luna/LunaClient-Minimal-10.7.2-16.x86_64.tar"
        tasks:
        - name: Create new barbican images with the Luna Minimal Client
          ansible.builtin.include_role:
@@ -83,7 +81,6 @@ You can also do the steps separately.
 | `barbican_dest_image_namespace` | string  | `podified-antelope-centos9`                                | Registry namespace for the modified images                  |
 | `barbican_dest_image_tag`       | string  | `current-podified-luna`                                    | Tag used to identify the modified images                    |
 | `luna_minclient_src`            | string  | `file:///opt/luna/LunaClient-Minimal-10.7.2-16.x86_64.tar` | Location of the Luna Minimal Client tarball                 |
-| `luna_minclient_dir`            | string  | `LunaClient-Minimal-10.7.2-16.x86_64`                      | Top level directory inside the Linux Minimal Client tarball |
 | `image_registry_verify_tls`     | boolean | `true`                                                     | Use TLS verification when pushing/pulling images            |
 
 ### Secret Generation Variables

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,8 +21,7 @@ cleanup: false
 working_dir: "/tmp/hsm-prep-working-dir"
 
 ### Luna Parameters
-luna_minclient_dir: "LunaClient-Minimal-10.7.2-16.x86_64"
-luna_minclient_src: "file:///opt/luna/{{ luna_minclient_dir }}.tar"
+luna_minclient_src: "file:///opt/luna/LunaClient-Minimal-10.7.2-16.x86_64.tar"
 luna_server_cert_src: "file:///opt/luna/cert/server/server.pem"
 luna_client_cert_src: "file:///opt/luna/cert/client/"
 luna_client_name: "barbican"

--- a/tasks/create_image.yml
+++ b/tasks/create_image.yml
@@ -38,6 +38,9 @@
       ansible.builtin.unarchive:
         src: "{{ working_dir }}/{{ luna_minclient_src | basename }}"
         dest: "{{ working_dir }}/client/"
+        extra_opts:
+          - "--strip"
+          - "1"
 
 - name: Download build tools
   become: true
@@ -56,7 +59,7 @@
     BARBICAN_DEST_IMAGE_REGISTRY: "{{ barbican_dest_image_registry }}"
     BARBICAN_DEST_IMAGE_NAMESPACE: "{{ barbican_dest_image_namespace }}"
     BARBICAN_DEST_IMAGE_TAG: "{{ barbican_dest_image_tag }}"
-    LUNA_LINUX_MINIMAL_CLIENT_DIR: "{{ working_dir }}/client/{{ luna_minclient_dir }}"
+    LUNA_LINUX_MINIMAL_CLIENT_DIR: "{{ working_dir }}/client"
     VERIFY_TLS: "{{ image_registry_verify_tls }}"
 
 - name: Perform cleanup tasks


### PR DESCRIPTION
This patch removes the need to specify the top level directory in the tarball.  Instead it just strips the top level without having to know the name of it.

This simplifies the deployment some because a user does not need to inspect the tarball contents to get the name of this directory.